### PR TITLE
examples: Fix the way that the gradient operator uses rec_tau

### DIFF
--- a/examples/seismic/stiffness/operators.py
+++ b/examples/seismic/stiffness/operators.py
@@ -206,10 +206,9 @@ def ForwardOperator(model, geometry, space_order=4, save=False, par='lam-mu', **
 
     src_expr, rec_expr = src_rec(v, tau, model, geometry)
 
-    op = Operator(eqn + src_expr + rec_expr, subs=model.spacing_map,
-                  name="ForwardIsoElastic", **kwargs)
     # Substitute spacing terms to reduce flops
-    return op
+    return Operator(eqn + src_expr + rec_expr, subs=model.spacing_map,
+                    name="ForwardIsoElastic", **kwargs)
 
 
 def AdjointOperator(model, geometry, space_order=4, par='lam-mu', **kwargs):
@@ -294,8 +293,9 @@ def GradientOperator(model, geometry, space_order=4, save=True, par='lam-mu', **
     if model.grid.dim == 3:
         rec_expr += rec_vy.inject(field=u[1].backward, expr=s*rec_vy/rho)
 
-    rec_p = kwargs.pop('rec_tau')
-    if rec_p:
+    if kwargs.pop('has_rec_p'):
+        rec_p = Receiver(name='rec_p', grid=model.grid, time_range=geometry.time_axis,
+                         npoint=geometry.nrec)
         rec_term_sigx = rec_p.inject(field=sig[0].backward, expr=s*rec_p/rho)
         rec_term_sigz = rec_p.inject(field=sig[1].backward, expr=s*rec_p/rho)
         rec_expr += rec_term_sigx + rec_term_sigz

--- a/examples/seismic/stiffness/wavesolver.py
+++ b/examples/seismic/stiffness/wavesolver.py
@@ -47,10 +47,11 @@ class IsoElasticWaveSolver(object):
                                space_order=self.space_order, par=par, **self._kwargs)
 
     @memoized_meth
-    def op_grad(self, save=True, par=None, rec_tau=None):
+    def op_grad(self, save=True, par=None, has_rec_p=None):
         """Cached operator for gradient runs"""
         return GradientOperator(self.model, save=save, geometry=self.geometry,
-                                space_order=self.space_order, par=par, rec_tau=rec_tau, **self._kwargs)
+                                space_order=self.space_order, par=par,
+                                has_rec_p=has_rec_p, **self._kwargs)
 
     def forward(self, src=None, rec_tau=None, rec_vx=None, rec_vz=None, rec_vy=None,
                 v=None, tau=None, model=None, save=None, par='lam-mu', **kwargs):
@@ -238,10 +239,10 @@ class IsoElasticWaveSolver(object):
         new_p = {k: v for k, v in parameters.items() if k not in remove_par[par]}
         kwargs.update(new_p)
 
-        rec_tau = kwargs.get('rec_tau', None)
-        summary = self.op_grad(par=par, rec_tau=rec_tau).apply(rec_vx=rec_vx, rec_vz=rec_vz, grad1=grad1,
-                                              grad2=grad2, grad3=grad3,
-                                              dt=kwargs.pop('dt', self.dt), **kwargs)
+        has_rec_p = True if kwargs.get('rec_p', None) else None
+        summary = self.op_grad(par=par, has_rec_p=has_rec_p).apply(rec_vx=rec_vx, rec_vz=rec_vz, grad1=grad1,
+                                                                   grad2=grad2, grad3=grad3,
+                                                                   dt=kwargs.pop('dt', self.dt), **kwargs)
 
         return grad1, grad2, grad3, summary
 


### PR DESCRIPTION
Fix the way that the gradient operator uses rec_tau and change the name of rec_tau to rec_p